### PR TITLE
Add reference to Enterprise Orbit Diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ A collection of awesome references regarding Software Architecture.
 
 - [Diagrams](https://diagrams.mingrammer.com/) - Diagrams lets you draw the cloud system architecture in Python code.
 
+- Edwin Castañeda: [Enterprise Orbit Diagram](https://github.com/edwincastaneda/enterprise-orbit-diagram) - A strategic visualization model designed for early discovery, low-documentation environments, and modernization conversations.
+
+
+
 ### Architectural Katas
 
 - [Architectural Katas](http://fundamentalsofsoftwarearchitecture.com/katas/) - Exercise being a Software Architect.


### PR DESCRIPTION
Added a reference to Edwin Castañeda's Enterprise Orbit Diagram for strategic visualization.

https://github.com/edwincastaneda/enterprise-orbit-diagram